### PR TITLE
Fix for using the machine key store

### DIFF
--- a/LxCommunciator.NET/Communicator/Session.cs
+++ b/LxCommunciator.NET/Communicator/Session.cs
@@ -131,7 +131,7 @@ namespace Loxone.Communicator {
 		private string PemToXml(string pem) {
 			return GetXmlRsaKey(pem, obj => {
 				var publicKey = (RsaKeyParameters)obj;
-				return DotNetUtilities.ToRSA(publicKey);
+				return DotNetUtilities.ToRSA(publicKey, new CspParameters { Flags = CspProviderFlags.UseMachineKeyStore });
 			}, rsa => rsa.ToXmlString(false));
 
 		}


### PR DESCRIPTION
When running DotNetUtilities.ToRSA in Azure, you will get an error:
System.Security.Cryptography.CryptographicException: The system cannot find the file specified.
To fix this ensure to provide the CspParameters Flags UseMachineKeyStore, see https://blogs.msdn.microsoft.com/winsdk/2009/11/16/opps-system-security-cryptography-cryptographicexception-the-system-cannot-find-the-file-specified/